### PR TITLE
Add ability to include named groups in tokens.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
     "require": {
         "php": ">=5.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "5.*"
+    },
     "autoload": {
         "psr-0": { "Phlexy": "lib/" }
     },

--- a/lib/Phlexy/Lexer/Stateless/WithCapturingGroups.php
+++ b/lib/Phlexy/Lexer/Stateless/WithCapturingGroups.php
@@ -6,11 +6,19 @@ class WithCapturingGroups implements \Phlexy\Lexer {
     protected $compiledRegex;
     protected $offsetToTokenMap;
     protected $offsetToLengthMap;
+    private $preferNamedGroups;
 
-    public function __construct($compiledRegex, array $offsetToTokenMap, array $offsetToLengthMap) {
+    /**
+     * @param string $compiledRegex
+     * @param array $offsetToTokenMap
+     * @param array $offsetToLengthMap
+     * @param bool $preferNamedGroups
+     */
+    public function __construct($compiledRegex, array $offsetToTokenMap, array $offsetToLengthMap, $preferNamedGroups = false) {
         $this->compiledRegex = $compiledRegex;
         $this->offsetToTokenMap = $offsetToTokenMap;
         $this->offsetToLengthMap = $offsetToLengthMap;
+        $this->preferNamedGroups = $preferNamedGroups;
     }
 
     public function lex($string) {
@@ -32,6 +40,20 @@ class WithCapturingGroups implements \Phlexy\Lexer {
             for ($j = 1, $length = $this->offsetToLengthMap[$i - 1]; $j < $length; ++$j) {
                 if (isset($matches[$i + $j])) {
                     $realMatches[$j] = $matches[$i + $j];
+
+                    if ($this->preferNamedGroups) {
+                        while (($key = key($matches)) !== $i + $j && $key !== false) {
+                            next($matches);
+                        }
+
+                        prev($matches);
+
+                        // remove corresponding indexed group
+                        if (is_string($k = key($matches))) {
+                            $realMatches[$k] = $realMatches[$j];
+                            unset($realMatches[$j]);
+                        }
+                    }
                 }
             }
 

--- a/lib/Phlexy/LexerFactory.php
+++ b/lib/Phlexy/LexerFactory.php
@@ -3,5 +3,10 @@
 namespace Phlexy;
 
 interface LexerFactory {
+    /**
+     * @param array $lexerDefinition
+     * @param string $additionalModifiers
+     * @return \Phlexy\Lexer
+     */
     public function createLexer(array $lexerDefinition, $additionalModifiers = '');
 }

--- a/lib/Phlexy/LexerFactory/Stateless/WithCapturingGroups.php
+++ b/lib/Phlexy/LexerFactory/Stateless/WithCapturingGroups.php
@@ -4,9 +4,15 @@ namespace Phlexy\LexerFactory\Stateless;
 
 class WithCapturingGroups implements \Phlexy\LexerFactory {
     protected $dataGen;
+    private $preferNamedGroups;
 
-    public function __construct(\Phlexy\LexerDataGenerator $dataGen) {
+    /**
+     * @param \Phlexy\LexerDataGenerator $dataGen
+     * @param bool $preferNamedGroups
+     */
+    public function __construct(\Phlexy\LexerDataGenerator $dataGen, $preferNamedGroups = false) {
         $this->dataGen = $dataGen;
+        $this->preferNamedGroups = $preferNamedGroups;
     }
 
     public function createLexer(array $lexerDefinition, $additionalModifiers = '') {
@@ -17,7 +23,7 @@ class WithCapturingGroups implements \Phlexy\LexerFactory {
         $offsetToTokenMap = array_combine(array_keys($offsetToLengthMap), $lexerDefinition);
 
         return new \Phlexy\Lexer\Stateless\WithCapturingGroups(
-            $compiledRegex, $offsetToTokenMap, $offsetToLengthMap
+            $compiledRegex, $offsetToTokenMap, $offsetToLengthMap, $this->preferNamedGroups
         );
     }
 }

--- a/test/Phlexy/Lexer/Stateless/WithCapturingGroupsTest.php
+++ b/test/Phlexy/Lexer/Stateless/WithCapturingGroupsTest.php
@@ -7,11 +7,35 @@ require_once __DIR__ . '/../TestAbstract.php';
 class WithCapturingGroupsTest extends \Phlexy\Lexer\TestAbstract {
     public function createLexerFactory() {
         return new \Phlexy\LexerFactory\Stateless\WithCapturingGroups(
-            new \Phlexy\LexerDataGenerator
+            new \Phlexy\LexerDataGenerator,
+            false
         );
     }
 
     public function provideTestLexing() {
         return $this->getTestsWithCapturingGroups();
+    }
+
+    public function testNamedGroups() {
+        $lexerFactory = new \Phlexy\LexerFactory\Stateless\WithCapturingGroups(
+            new \Phlexy\LexerDataGenerator,
+            true
+        );
+
+        $lexer = $lexerFactory->createLexer(
+            array(
+                '\s+'          => 0,
+                '\$(?<varName>\w+)'      => 1,
+                '(?<intPart>\d+)\.(?<fractionalPart>\d+)' => 2
+            )
+        );
+
+        $this->assertEquals(array(
+            array(1, 1, '$foo', array('varName' => 'foo')),
+            array(0, 1, ' '),
+            array(2, 1, '3.141', array('intPart' => '3', 'fractionalPart' => '141')),
+            array(0, 1, ' '),
+            array(1, 1, '$bar', array('varName' => 'bar')),
+        ), $lexer->lex('$foo 3.141 $bar'));
     }
 }


### PR DESCRIPTION
I found useful to capture named groups, indexed ones are very confusing. However, I couldn't find easy way to write test in the same test organization, but I think it's not that important right now.

P.S. Probably, it makes sense to make new major version of Phlexy:
1. update codebase (it's too legacy; these factories could be inlined into lexers themselves with static named constructors as they are static services in fact; better names, etc.);
2. add feature to generate classes as final stage of lexer developing, e.g. https://gist.github.com/unkind/b6202906946f243063fc3d8cf1a7ad5f;
3. remove "experimental" label.